### PR TITLE
rename timeout to delay (how long to sleep between invocations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ an instance of it as a public field, annotated with `@Rule`.
 
 Then, for any test that needs to implement retrying logic, annotate
 the method with `@Retry`. Optional parameters on this annotation let
-you change defaults such as the number of retries, the timeout length,
+you change defaults such as the number of retries, the delay length,
 etc.
 
 ```java

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.kevinmost'
-version '1.0-SNAPSHOT'
+version '1.1-SNAPSHOT'
 
 apply plugin: 'java'
 

--- a/src/main/java/com/kevinmost/junit_retry_rule/Retry.java
+++ b/src/main/java/com/kevinmost/junit_retry_rule/Retry.java
@@ -21,5 +21,5 @@ public @interface Retry {
   /**
    * @return how long to sleep between invocations of the unit tests, in milliseconds
    */
-  long timeout() default 0;
+  long delay() default 0;
 }

--- a/src/main/java/com/kevinmost/junit_retry_rule/RetryRule.java
+++ b/src/main/java/com/kevinmost/junit_retry_rule/RetryRule.java
@@ -25,10 +25,10 @@ public final class RetryRule implements TestRule {
           "@" + Retry.class.getSimpleName() + " cannot be used with a \"times\" parameter less than 1"
       );
     }
-    final long timeout = retryAnnotation.timeout();
-    if (timeout < 0) {
+    final long delay = retryAnnotation.delay();
+    if (delay < 0) {
       throw new IllegalArgumentException(
-          "@" + Retry.class.getSimpleName() + " cannot be used with a \"timeout\" parameter less than 0"
+          "@" + Retry.class.getSimpleName() + " cannot be used with a \"delay\" parameter less than 0"
       );
     }
 
@@ -43,7 +43,7 @@ public final class RetryRule implements TestRule {
           } catch (Throwable t) {
             errors[currentAttempt] = t;
             currentAttempt++;
-            Thread.sleep(timeout);
+            Thread.sleep(delay);
           }
         }
         throw RetryException.from(errors);


### PR DESCRIPTION
Timeout name was misleading, especially used next to `@Test(timeout=100)`

> timeout in milliseconds to cause a test method to fail if it takes longer than that number of milliseconds.

http://junit.org/junit4/javadoc/4.12/org/junit/Test.html#timeout()

>  - how long to sleep between invocations of the unit tests, in milliseconds

junit-retry-rule