### PR TITLE
Ignore skipped tests on retry

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,22 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <resourceExtensions />
-    <wildcardResourcePatterns>
-      <entry name="!?*.java" />
-      <entry name="!?*.form" />
-      <entry name="!?*.class" />
-      <entry name="!?*.groovy" />
-      <entry name="!?*.scala" />
-      <entry name="!?*.flex" />
-      <entry name="!?*.kt" />
-      <entry name="!?*.clj" />
-      <entry name="!?*.aj" />
-    </wildcardResourcePatterns>
-    <annotationProcessing>
-      <profile default="true" name="Default" enabled="false">
-        <processorPath useClasspath="true" />
-      </profile>
-    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="junit-retry-rule_main" target="1.8" />
+      <module name="junit-retry-rule_test" target="1.8" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="ProjectInspectionProfilesVisibleTreeState">
     <entry key="Project Default">
       <profile-state>
@@ -37,67 +34,7 @@
       </profile-state>
     </entry>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
-  </component>
-  <component name="masterDetails">
-    <states>
-      <state key="GlobalLibrariesConfigurable.UI">
-        <settings>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-      <state key="JdkListConfigurable.UI">
-        <settings>
-          <last-edited>1.8</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-      <state key="ProjectJDKs.UI">
-        <settings>
-          <last-edited>1.8</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-      <state key="ProjectLibrariesConfigurable.UI">
-        <settings>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-    </states>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,8 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/junit-retry-rule.iml" filepath="$PROJECT_DIR$/.idea/modules/junit-retry-rule.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/junit-retry-rule_main.iml" filepath="$PROJECT_DIR$/.idea/modules/junit-retry-rule_main.iml" group="junit-retry-rule" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/junit-retry-rule_test.iml" filepath="$PROJECT_DIR$/.idea/modules/junit-retry-rule_test.iml" group="junit-retry-rule" />
     </modules>
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,17 @@
 group 'com.kevinmost'
-version '1.0-SNAPSHOT'
+version '1.1-SNAPSHOT'
 
 apply plugin: 'java'
 
-sourceCompatibility = JavaVersion.VERSION_1_5
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  compile(
+  implementation(
       "junit:junit:4.12",
       "org.jetbrains:annotations:13.0",
   )
-}
-
-task wrapper(type: Wrapper) {
-  gradleVersion = "2.14.1"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip

--- a/src/main/java/com/kevinmost/junit_retry_rule/RetryException.java
+++ b/src/main/java/com/kevinmost/junit_retry_rule/RetryException.java
@@ -9,12 +9,12 @@ import java.io.StringWriter;
  * An exception thrown to signal that a retry operation (executed via {@link RetryRule}) has retried more than the
  * allowed number of times, and has still failed.
  */
-public final class RetryException extends RuntimeException {
+final class RetryException extends RuntimeException {
 
   /**
    * @param errors the errors for each attempt at running this test-case
    */
-  @NotNull public static RetryException from(@NotNull Throwable[] errors) {
+  @NotNull static RetryException from(@NotNull Throwable[] errors) {
     final StringBuilder msg = new StringBuilder("Invoked methods still failed after " + errors.length + " attempts.");
     for (int i = 0; i < errors.length; i++) {
       final Throwable error = errors[i];
@@ -28,7 +28,6 @@ public final class RetryException extends RuntimeException {
   private RetryException(@NotNull String message) {
     super(message);
   }
-
 
   @NotNull private static String stackTraceAsString(@NotNull Throwable t) {
     final StringWriter errors = new StringWriter();

--- a/src/main/java/com/kevinmost/junit_retry_rule/RetryRule.java
+++ b/src/main/java/com/kevinmost/junit_retry_rule/RetryRule.java
@@ -41,6 +41,10 @@ public final class RetryRule implements TestRule {
             base.evaluate();
             return;
           } catch (Throwable t) {
+            // ignore skipped tests
+            if (t instanceof org.junit.AssumptionViolatedException ) {
+              throw t;
+            }
             errors[currentAttempt] = t;
             currentAttempt++;
             Thread.sleep(timeout);
@@ -56,7 +60,7 @@ public final class RetryRule implements TestRule {
    * Throwable encountered when running the test-case for the first time, {@code errors()[1]} corresponds to the
    * Throwable encountered when running the test-case for the second time, and so on.
    */
-  @NotNull public Throwable[] errors() {
+  @NotNull private Throwable[] errors() {
     return Arrays.copyOfRange(errors, 0, currentAttempt);
   }
 


### PR DESCRIPTION
JUnit allows to conditionally skip tests through `assumeThat()`. If such a condition fails, a `AssumptionViolatedException` is generated and thrown that effectively ends the test, but marks it as skipped, not as failed.
The rule now recognizes this exception and throws it further.